### PR TITLE
Исправления и фиксы для API, компонента ThemeSwitcher, миграций и сидов 

### DIFF
--- a/packages/client/src/api/constants.ts
+++ b/packages/client/src/api/constants.ts
@@ -19,10 +19,11 @@ export const serviceIdURL = oauth + '/yandex/service-id'
 export const oauthURL = oauth + '/yandex'
 
 // theme api
-export const getThemesUrl = `${apiHost}/theme-api/themes`
-export const getUserThemeUrl = (userId: string) =>
-  `${apiHost}/theme-api/theme/${userId}`
-export const setUserThemeUrl = `${apiHost}/theme-api/theme`
+const themePrefix = '/api/themes'
+export const getThemesUrl = themePrefix
+export const getUserThemeUrl = (userId: number) =>
+  `${themePrefix}/theme/${userId.toString()}`
+export const setUserThemeUrl = `${themePrefix}/theme`
 
 //заменить после деплоя
 export const redirectURL = apiHost

--- a/packages/client/src/components/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/packages/client/src/components/ThemeSwitcher/ThemeSwitcher.tsx
@@ -1,5 +1,3 @@
-// ThemeSwitcher.tsx
-
 import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { themesSelector, currentThemeSelector } from '@/ducks/theme/selectors'
@@ -27,10 +25,8 @@ export const ThemeSwitcher: React.FC = () => {
     const newThemeId = isDarkTheme ? ThemeType.LIGHT : ThemeType.DARK
     const selectedTheme = themes.find(t => t.id === newThemeId)
     if (selectedTheme) {
-      if (user) {
-        dispatch(
-          setUserTheme({ userId: user.id.toString(), themeId: newThemeId }),
-        )
+      if (user && user.id) {
+        dispatch(setUserTheme({ userId: user.id, themeId: newThemeId }))
         localStorage.setItem('themeId', newThemeId.toString())
       } else {
         dispatch(setCurrentTheme(selectedTheme))
@@ -38,10 +34,6 @@ export const ThemeSwitcher: React.FC = () => {
       }
     }
   }
-
-  useEffect(() => {
-    console.log('currentTheme', currentTheme)
-  }, [currentTheme])
 
   useEffect(() => {
     if (isDarkTheme) {

--- a/packages/client/src/ducks/theme/slices.ts
+++ b/packages/client/src/ducks/theme/slices.ts
@@ -9,6 +9,7 @@ export const fetchThemes = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await api<undefined, AxiosResponse<ThemeData[]>>({
+        baseURL: '/',
         url: getThemesUrl,
         method: Methods.GET,
       })
@@ -22,9 +23,10 @@ export const fetchThemes = createAsyncThunk(
 
 export const getUserTheme = createAsyncThunk(
   'theme/getUserTheme',
-  async (userId: string, { rejectWithValue }) => {
+  async (userId: number, { rejectWithValue }) => {
     try {
       const response = await api<undefined, AxiosResponse<ThemeData>>({
+        baseURL: '/',
         url: getUserThemeUrl(userId),
         method: Methods.GET,
       })
@@ -39,11 +41,12 @@ export const getUserTheme = createAsyncThunk(
 export const setUserTheme = createAsyncThunk(
   'theme/setUserTheme',
   async (
-    { userId, themeId }: { userId: string; themeId: number },
+    { userId, themeId }: { userId: number; themeId: number },
     { rejectWithValue },
   ) => {
     try {
       await api<undefined, AxiosResponse<void>>({
+        baseURL: '/',
         url: setUserThemeUrl,
         method: Methods.POST,
         data: { user_id: userId, theme_id: themeId },

--- a/packages/client/src/ducks/user/slices.ts
+++ b/packages/client/src/ducks/user/slices.ts
@@ -24,6 +24,7 @@ import {
   signinURL,
   signupURL,
   staticURL,
+  apiPrefix,
 } from '@/api/constants'
 
 const initialState: UserState = {
@@ -39,6 +40,7 @@ export const signup = createAsyncThunk(
   async (data: SignupData, { dispatch, rejectWithValue }) => {
     try {
       const response = await api<undefined, AxiosResponse<SignupResponse>>({
+        baseURL: apiPrefix,
         url: signupURL,
         method: Methods.POST,
         data: data,
@@ -61,6 +63,7 @@ export const signin = createAsyncThunk(
   async (data: SigninData, { rejectWithValue, dispatch }) => {
     try {
       const response = await api<undefined, AxiosResponse<UserResponse>>({
+        baseURL: apiPrefix,
         url: signinURL,
         method: Methods.POST,
         data: data,
@@ -82,6 +85,7 @@ export const getOauthServiceId = createAsyncThunk(
   async (_, { rejectWithValue }) => {
     try {
       const response = await api<undefined, AxiosResponse<ServiceIdResponse>>({
+        baseURL: apiPrefix,
         url: serviceIdURL,
         params: { redirect_uri: redirectURL },
       })
@@ -104,6 +108,7 @@ export const getOauthAccessToken = createAsyncThunk(
   async (serviceId: string, { rejectWithValue, dispatch }) => {
     try {
       await api<undefined, AxiosResponse<Blob>>({
+        baseURL: apiPrefix,
         url: oauthURL,
         method: Methods.POST,
         data: { redirect_uri: redirectURL, code: serviceId },
@@ -124,6 +129,7 @@ export const logout = createAsyncThunk(
   async (_, { rejectWithValue, dispatch }) => {
     try {
       await api<undefined, AxiosResponse<string>>({
+        baseURL: apiPrefix,
         url: logoutURL,
         method: Methods.POST,
       })
@@ -143,6 +149,7 @@ export const sendGameData = createAsyncThunk(
   async (gameData: GameDataType) => {
     try {
       const response = await api({
+        baseURL: apiPrefix,
         url: addUserToLeaderbordURL,
         method: Methods.POST,
         data: {
@@ -162,6 +169,7 @@ export const getLeaderboard = createAsyncThunk(
   async (params: LeaderboardParams, { rejectWithValue }) => {
     try {
       const response = await api<undefined, AxiosResponse<LeaderboardParams>>({
+        baseURL: apiPrefix,
         url: getAllLeaderboardURL,
         method: Methods.POST,
         data: params,
@@ -182,6 +190,7 @@ export const getUser = createAsyncThunk(
   async (cookies: string | undefined, { rejectWithValue, dispatch }) => {
     try {
       const response = await api<undefined, AxiosResponse<UserResponse>>({
+        baseURL: apiPrefix,
         url: getUserURL,
         headers: {
           Cookie: cookies,
@@ -213,6 +222,7 @@ export const getUserAvatar = createAsyncThunk(
   ) => {
     try {
       const response = await api<undefined, AxiosResponse<Blob>>({
+        baseURL: apiPrefix,
         url: staticURL + pathToFile,
         method: Methods.GET,
         responseType: 'blob',

--- a/packages/client/src/router/index.tsx
+++ b/packages/client/src/router/index.tsx
@@ -98,9 +98,9 @@ const Auth: FC<PropsWithChildren<{ path?: string }>> = ({ path, children }) => {
   const isAuthorized = Boolean(user)
 
   useEffect(() => {
-    if (user && localStorage.getItem('themeId')) {
+    if (user && user.id && localStorage.getItem('themeId')) {
       const themeId = parseInt(localStorage.getItem('themeId')!, 10)
-      dispatch(setUserTheme({ userId: user.id.toString(), themeId }))
+      dispatch(setUserTheme({ userId: user.id, themeId }))
       dispatch(setCurrentTheme({ id: themeId, name: '' }))
       localStorage.removeItem('themeId')
     }
@@ -109,11 +109,15 @@ const Auth: FC<PropsWithChildren<{ path?: string }>> = ({ path, children }) => {
   useEffect(() => {
     dispatch(fetchThemes())
 
-    if (user) {
-      dispatch(getUserTheme(user.id.toString()))
+    if (user && user.id) {
+      dispatch(getUserTheme(user.id))
     } else {
       const storedThemeId = localStorage.getItem('themeId')
-      if (storedThemeId && storedThemeId !== currentTheme?.id.toString()) {
+      if (
+        storedThemeId &&
+        currentTheme?.id &&
+        storedThemeId !== currentTheme.id.toString()
+      ) {
         const themeId = parseInt(storedThemeId, 10)
         dispatch(setCurrentTheme({ id: themeId, name: '' }))
       }

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -16,7 +16,7 @@ dotenv.config()
 import createCache from '@emotion/cache'
 import type { EmotionCache } from '@emotion/cache'
 import createEmotionServer from '@emotion/server/create-instance'
-import router from './src/routes/themeRoutes'
+import themeRouter from './src/routes/themeRoutes'
 import forumRouter from './src/routes/forumRoutes'
 
 export const apiHost = 'https://ya-praktikum.tech'
@@ -65,9 +65,7 @@ async function startServer(isDev = process.env.NODE_ENV === 'development') {
   )
 
   app.use(express.json())
-
-  app.use('/theme-api', themeRouter)
-  app.use('/api', router)
+  app.use('/api/themes', themeRouter)
   app.use('/api/forum', forumRouter)
 
   app.use('*', async (req, res, next) => {

--- a/packages/server/src/routes/themeRoutes.ts
+++ b/packages/server/src/routes/themeRoutes.ts
@@ -9,6 +9,6 @@ const router = Router()
 
 router.post('/theme', setUserTheme)
 router.get('/theme/:user_id', getUserTheme)
-router.get('/themes', getThemes)
+router.get('/', getThemes)
 
 export default router

--- a/packages/server/src/sequelize/migrations/20241107114652-create-user-themes.js
+++ b/packages/server/src/sequelize/migrations/20241107114652-create-user-themes.js
@@ -5,7 +5,7 @@ module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable('user_themes', {
       user_id: {
-        type: Sequelize.STRING,
+        type: Sequelize.INTEGER,
         primaryKey: true,
       },
       theme_id: {

--- a/packages/server/src/sequelize/seeders/20241107115633-add-themes.js
+++ b/packages/server/src/sequelize/seeders/20241107115633-add-themes.js
@@ -1,15 +1,23 @@
-'use strict';
+'use strict'
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
-  async up(queryInterface, Sequelize) {
-    await queryInterface.bulkInsert('themes', [
-      { id: 1, name: 'Светлая' },
-      { id: 2, name: 'Темная' },
-    ]);
+  up: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkInsert('themes', [
+        { id: 1, name: 'Светлая' },
+        { id: 2, name: 'Темная' },
+      ]);
+    } catch (error) {
+      console.error('Ошибка при создании данных для таблицы themes:', error)
+    }
   },
 
-  async down(queryInterface, Sequelize) {
-    await queryInterface.bulkDelete('themes', null, {});
-  }
-};
+  down: async (queryInterface, Sequelize) => {
+    try {
+      await queryInterface.bulkDelete('themes', null, {});
+    } catch (error) {
+      console.error('Ошибка при удалении данных из таблицы themes:', error)
+    }
+  },
+}


### PR DESCRIPTION
Это сборный пакет фиксов, который содержит в себе следующие изменения:

- Изменение миграций и сидов для Sequelize
  - Миграции: тип поля `user_id` в таблице `user_themes` был изменен на `number` (ранее был установлен в `string`, потому что по привычке работы с MongoDB я ожидал, что API Яндекса вернет строку). После того как примените данное обновление, не забудьте откатить и заново провести миграции таблиц с темами.
  - Сиды: взял за основу предложение @RustamKurbonov c оберткой в `try/catch`, но из варианта Рустама убрал импорт модели - с импортом сид не отрабатывал, без него - работает. Поэтому убрал.
- Изменения серверной части:
  - Привел URL API изменения тем к единообразию: `theme-api` -> `api/themes`
  - Исправил ошибку, вызванную коллизией с PR @DieReiterin, заменив импорт `router` на `themeRouter`
- Изменения клиентской части:
  - Привел в соответствие с изменениями в серверной части URL API на клиентской стороне
  - Добавил относительный URL в качестве `baseURL` в вызовах API в слайсах, чтобы избежать ошибок работы с API, если переменная окружения в Vite не была задана. Иначе это приводило к следующей ошибке:
  
  ![image](https://github.com/user-attachments/assets/3e0d7ac9-7237-46a9-a245-d0c651cbdc83)

  - Удалил случайно оставленный `console.log`
  - Обновил компонент `ThemeSwitcher`:
    - Изменил тип поля `id` со строки на число (в соответствии с изменениями в БД)
    - Добавил проверок на наличие поля `id`, чтобы не возникали ошибки, в случае проблем с подключением к БД
